### PR TITLE
Upgrade PG components to release v12

### DIFF
--- a/bundle/manifests/tackle-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tackle-operator.clusterserviceversion.yaml
@@ -122,11 +122,11 @@ spec:
                 - name: TACKLE_HUB_IMAGE
                   value: quay.io/jortel/tackle-hub:latest
                 - name: PATHFINDER_DATABASE_IMAGE
-                  value: postgres:10
+                  value: postgres:12
                 - name: PATHFINDER_API_IMAGE
                   value: quay.io/konveyor/tackle-pathfinder:1.1.0-native
                 - name: KEYCLOAK_DATABASE_IMAGE
-                  value: postgres:10
+                  value: postgres:12
                 - name: KEYCLOAK_SSO_IMAGE
                   value: quay.io/keycloak/keycloak:12.0.4
                 - name: TACKLE_UI_IMAGE


### PR DESCRIPTION
- PG10 will be EOL by November this year, see https://www.postgresql.org/support/versioning/
- Tested Keycloak and Pathfinder base functionality
- Use floating 12 tag for CVE sanity