### PR TITLE
RBAC: tackle-hub SA updates

### DIFF
--- a/bundle/manifests/tackle-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tackle-operator.clusterserviceversion.yaml
@@ -229,6 +229,16 @@ spec:
           - patch
           - update
           - watch
+      - serviceAccountName: tackle-hub
+        rules:
+        - apiGroups:
+          - ""
+          - tackle.konveyor.io
+          - batch
+          resources:
+          - '*'
+          verbs:
+          - '*'
       clusterPermissions:
       - serviceAccountName: tackle-operator
         rules:
@@ -238,16 +248,6 @@ spec:
           - clusterversions
           verbs:
           - get
-      - serviceAccountName: tackle-hub
-        rules:
-        - apiGroups:
-          - tackle.konveyor.io
-          resources:
-          - addons
-          verbs:
-          - get
-          - list
-          - watch
     strategy: deployment
   installModes:
   - supported: true


### PR DESCRIPTION
- Convert tackle-hub sa to cluster role
- Apply RBAC updates requested in #8